### PR TITLE
move registry logic to registry package subfolder

### DIFF
--- a/client/balancer/pkg.go
+++ b/client/balancer/pkg.go
@@ -2,131 +2,29 @@ package balancer
 
 import (
     "fmt"
-    "sync"
     //
-    "golang.org/x/net/context"
     "google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
     //
     "github.com/GuruSystems/framework/client"
-    "github.com/GuruSystems/framework/client/registry"
-    "gitlab.gurusys.co.uk/guru/proto/slackgateway"
-	pb "github.com/GuruSystems/framework/proto/registrar"
 )
 
-type ServiceManager struct {
-    waitGroup *sync.WaitGroup
-    grpcClient interface{}
-    connections map[*Host]struct{}
-    sync.RWMutex
-}
-
-type Host struct {
-    manager *ServiceManager
-    waitGroup *sync.WaitGroup
-    address string
-    clientConn *grpc.ClientConn
-    killChannel chan struct{}
-    sync.RWMutex
-}
-
 // opens a tcp connection to a gurupath.
-func NewServiceManager(serviceName string) (*ServiceManager, error) {
+func DialService(serviceName string) (*grpc.ClientConn, error) {
 
-    manager := &ServiceManager{
-        waitGroup: &sync.WaitGroup{},
-        connections: map[*Host]struct{}{},
-    }
+    creds := client.GetClientCreds()
 
-	serverAddresses, err := registry.GetHosts(serviceName, pb.Apitype_tcp)
+    conn, err := grpc.Dial(
+        serviceName,
+        grpc.WithBlock(),
+        grpc.WithBalancer(
+            grpc.RoundRobin(&RegistryResolver{}),
+        ),
+        grpc.WithTransportCredentials(creds),
+    )
     if err != nil {
         return nil, err
     }
 
-    for _, address := range serverAddresses {
-
-        host := &Host{
-            manager: manager,
-            waitGroup: &sync.WaitGroup{},
-            address: address,
-            killChannel: make(chan struct{}),
-        }
-
-        manager.Lock()
-        manager.connections[host] = struct{}{}
-        manager.Unlock()
-
-        go host.Connection()
-
-    }
-
-    return manager, nil
-}
-
-func (manager *ServiceManager) SlackGatewayClient() *slackgateway.SlackGatewayClient {
-
-    manager.waitGroup.Wait()
-    return manager.grpcClient.(*slackgateway.SlackGatewayClient)
-}
-
-func (manager *ServiceManager) RemoveHost(host *Host) {
-    manager.Lock()
-    delete(manager.connections, host)
-    manager.Unlock()
-}
-
-func (host *Host) Remove() {
-    host.manager.RemoveHost(host)
-}
-
-func (host *Host) Connection() {
-
-    var s connectivity.State
-    creds := client.GetClientCreds()
-
-    for {
-        select {
-            case <- host.killChannel:
-
-                fmt.Println("STOPPING GOROUTINE FOR HOST: "+host.address)
-                return
-
-            default:
-        }
-
-        host.waitGroup.Add(1)
-
-        clientConn, err := grpc.Dial(
-            host.address,
-            grpc.WithTransportCredentials(creds),
-        )
-        if err != nil {
-            fmt.Println(
-                fmt.Errorf("Error dialling servicename @ %s\n", host.address),
-            )
-            continue
-        }
-
-        host.waitGroup.Done()
-
-    	for clientConn != nil {
-
-            host.Lock()
-            host.clientConn = clientConn
-            host.Unlock()
-
-    		clientConn.WaitForStateChange(context.Background(), s)
-
-			s = clientConn.GetState()
-            fmt.Println("state has changed", s)
-
-			if s == connectivity.TransientFailure || s == connectivity.Shutdown {
-				break
-			}
-
-        }
-
-        host.waitGroup.Add(1)
-    }
-
+    fmt.Println("STARTED SERVICE CLIENT: "+serviceName)
+    return conn, nil
 }

--- a/client/balancer/pkg.go
+++ b/client/balancer/pkg.go
@@ -1,0 +1,132 @@
+package balancer
+
+import (
+    "fmt"
+    "sync"
+    //
+    "golang.org/x/net/context"
+    "google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+    //
+    "github.com/GuruSystems/framework/client"
+    "github.com/GuruSystems/framework/client/registry"
+    "gitlab.gurusys.co.uk/guru/proto/slackgateway"
+	pb "github.com/GuruSystems/framework/proto/registrar"
+)
+
+type ServiceManager struct {
+    waitGroup *sync.WaitGroup
+    grpcClient interface{}
+    connections map[*Host]struct{}
+    sync.RWMutex
+}
+
+type Host struct {
+    manager *ServiceManager
+    waitGroup *sync.WaitGroup
+    address string
+    clientConn *grpc.ClientConn
+    killChannel chan struct{}
+    sync.RWMutex
+}
+
+// opens a tcp connection to a gurupath.
+func NewServiceManager(serviceName string) (*ServiceManager, error) {
+
+    manager := &ServiceManager{
+        waitGroup: &sync.WaitGroup{},
+        connections: map[*Host]struct{}{},
+    }
+
+	serverAddresses, err := registry.GetHosts(serviceName, pb.Apitype_tcp)
+    if err != nil {
+        return nil, err
+    }
+
+    for _, address := range serverAddresses {
+
+        host := &Host{
+            manager: manager,
+            waitGroup: &sync.WaitGroup{},
+            address: address,
+            killChannel: make(chan struct{}),
+        }
+
+        manager.Lock()
+        manager.connections[host] = struct{}{}
+        manager.Unlock()
+
+        go host.Connection()
+
+    }
+
+    return manager, nil
+}
+
+func (manager *ServiceManager) SlackGatewayClient() *slackgateway.SlackGatewayClient {
+
+    manager.waitGroup.Wait()
+    return manager.grpcClient.(*slackgateway.SlackGatewayClient)
+}
+
+func (manager *ServiceManager) RemoveHost(host *Host) {
+    manager.Lock()
+    delete(manager.connections, host)
+    manager.Unlock()
+}
+
+func (host *Host) Remove() {
+    host.manager.RemoveHost(host)
+}
+
+func (host *Host) Connection() {
+
+    var s connectivity.State
+    creds := client.GetClientCreds()
+
+    for {
+        select {
+            case <- host.killChannel:
+
+                fmt.Println("STOPPING GOROUTINE FOR HOST: "+host.address)
+                return
+
+            default:
+        }
+
+        host.waitGroup.Add(1)
+
+        clientConn, err := grpc.Dial(
+            host.address,
+            grpc.WithTransportCredentials(creds),
+        )
+        if err != nil {
+            fmt.Println(
+                fmt.Errorf("Error dialling servicename @ %s\n", host.address),
+            )
+            continue
+        }
+
+        host.waitGroup.Done()
+
+    	for clientConn != nil {
+
+            host.Lock()
+            host.clientConn = clientConn
+            host.Unlock()
+
+    		clientConn.WaitForStateChange(context.Background(), s)
+
+			s = clientConn.GetState()
+            fmt.Println("state has changed", s)
+
+			if s == connectivity.TransientFailure || s == connectivity.Shutdown {
+				break
+			}
+
+        }
+
+        host.waitGroup.Add(1)
+    }
+
+}

--- a/client/balancer/pkg_test.go
+++ b/client/balancer/pkg_test.go
@@ -1,0 +1,25 @@
+package balancer
+
+import (
+    "testing"
+)
+
+func TestNewServiceManager(t *testing.T) {
+
+    service, err := NewServiceManager("slackgateway.SlackGateway")
+    if err != nil {
+        t.Error(err)
+    }
+
+    req := &pb.PublishMessageRequest{
+        Channel: "bot",
+        Text: *flag_message + " @AlexB " + strconv.Itoa(x),
+    }
+
+    resp, err := service.SlackGatewayClient().PublishMessage(client.SetAuthToken(), req)
+    if err != nil {
+        fmt.Println("FAILED TO PUBLISH", req, err)
+        continue
+    }
+
+}

--- a/client/balancer/pkg_test.go
+++ b/client/balancer/pkg_test.go
@@ -1,25 +1,38 @@
 package balancer
 
 import (
+    "fmt"
+    "flag"
+    "strconv"
     "testing"
+    //
+	"github.com/GuruSystems/framework/client"
+    slackgateway "gitlab.gurusys.co.uk/guru/proto/slackgateway"
 )
 
 func TestNewServiceManager(t *testing.T) {
 
-    service, err := NewServiceManager("slackgateway.SlackGateway")
+    flag.Parse()
+
+    service, err := SlackGatewayClient()
     if err != nil {
         t.Error(err)
+        return
     }
 
-    req := &pb.PublishMessageRequest{
-        Channel: "bot",
-        Text: *flag_message + " @AlexB " + strconv.Itoa(x),
-    }
+    for x := 0; x < 10; x ++ {
 
-    resp, err := service.SlackGatewayClient().PublishMessage(client.SetAuthToken(), req)
-    if err != nil {
-        fmt.Println("FAILED TO PUBLISH", req, err)
-        continue
-    }
+        req := &slackgateway.PublishMessageRequest{
+            Channel: "bot",
+            Text: "framework/client/balancer "+strconv.Itoa(x),
+        }
 
+        _, err = service.PublishMessage(client.SetAuthToken(), req)
+        if err != nil {
+            fmt.Println("FAILED TO PUBLISH", req, err)
+            t.Error(err)
+            return
+        }
+
+    }
 }

--- a/client/balancer/resolver.go
+++ b/client/balancer/resolver.go
@@ -1,0 +1,44 @@
+package balancer
+
+import (
+//	"fmt"
+	//
+	"google.golang.org/grpc/naming"
+	"github.com/GuruSystems/framework/client/registry"
+	pb "github.com/GuruSystems/framework/proto/registrar"
+)
+
+type RegistryResolver struct{}
+
+func (r *RegistryResolver) Resolve(serviceName string) (naming.Watcher, error) {
+
+	serverAddresses, err := registry.GetHosts(serviceName, pb.Apitype_grpc)
+    if err != nil {
+        return nil, err
+    }
+
+	var ups []*naming.Update
+	for _,a := range serverAddresses {
+		ups = append(
+			ups,
+			&naming.Update{naming.Add, a, ""},
+		)
+	}
+
+	var ch chan []*naming.Update = make(chan []*naming.Update, 1)
+	ch <- ups
+
+	return &staticWatcher{ch}, nil
+}
+
+type staticWatcher struct {
+	updates chan []*naming.Update
+}
+
+func (w *staticWatcher) Next() ([]*naming.Update, error) {
+	return <-w.updates, nil
+}
+
+func (w *staticWatcher) Close() {
+	close(w.updates)
+}

--- a/client/balancer/service_slackgateway.go
+++ b/client/balancer/service_slackgateway.go
@@ -1,0 +1,16 @@
+package balancer
+
+import (
+    "gitlab.gurusys.co.uk/guru/proto/slackgateway"
+)
+
+// Initialises a client
+func SlackGatewayClient() (slackgateway.SlackGatewayClient, error) {
+
+    conn, err := DialService("slackgateway.SlackGateway")
+    if err != nil {
+        return nil, err
+    }
+
+    return slackgateway.NewSlackGatewayClient(conn), nil
+}

--- a/client/registry/pkg.go
+++ b/client/registry/pkg.go
@@ -81,12 +81,11 @@ func HostList(serviceName string, apiType pb.Apitype) ([]*pb.GetResponse, error)
         grpc.WithTimeout(time.Duration(CONST_CALL_TIMEOUT) * time.Second),
     )
     if err != nil {
-        return nil, fmt.Errorf("Error dialling servicename %s @ %s\n", serviceName, registryAddress)
+        return nil, fmt.Errorf("HostList - Error dialling servicename %s @ %s\n", serviceName, registryAddress)
     }
     defer conn.Close()
 
-    grpcRegistryClient := pb.NewRegistryClient(conn)
-    list, err := grpcRegistryClient.GetTarget(
+    list, err := pb.NewRegistryClient(conn).GetTarget(
         context.Background(),
         &pb.GetTargetRequest{
             Name: serviceName,
@@ -94,8 +93,10 @@ func HostList(serviceName string, apiType pb.Apitype) ([]*pb.GetResponse, error)
         },
     )
     if err != nil {
-        return nil, fmt.Errorf("Error getting grpc service address %s: %s\n", serviceName, err)
+        return nil, fmt.Errorf("HostList - Error getting grpc service address %s: %s\n", serviceName, err)
     }
+
+    fmt.Println("REGISTRY", registryAddress, "LISTING", serviceName, ":", list.Service)
 
     return list.Service, nil
 }

--- a/client/registry/pkg.go
+++ b/client/registry/pkg.go
@@ -1,0 +1,101 @@
+package registry
+
+import (
+    "fmt"
+    "time"
+    //
+    "golang.org/x/net/context"
+    "google.golang.org/grpc"
+    //
+	"github.com/GuruSystems/framework/cmdline"
+	pb "github.com/GuruSystems/framework/proto/registrar"
+)
+
+const (
+    CONST_CALL_TIMEOUT = 2
+)
+
+// This function gets a host and returns it's host:port address.
+func GetHost(serviceName string, apiType pb.Apitype) (string, error) {
+
+    list, err := HostList(serviceName, apiType)
+    if err != nil {
+        return "", err
+    }
+
+    if len(list) == 0 {
+        return "", fmt.Errorf("No grpc target found for name %s", serviceName)
+    }
+
+    if len(list[0].Location.Address) == 0 {
+        return "", fmt.Errorf("No grpc location found for name %s - is it running?", serviceName)
+    }
+
+    return fmt.Sprintf(
+        "%s:%d",
+        list[0].Location.Address[0].Host,
+        list[0].Location.Address[0].Port,
+    ), nil
+}
+
+// This function gets the hosts and returns their host:port address.
+func GetHosts(serviceName string, apiType pb.Apitype) ([]string, error) {
+
+    list, err := HostList(serviceName, apiType)
+    if err != nil {
+        return nil, err
+    }
+
+    if len(list) == 0 {
+        return nil, fmt.Errorf("No grpc target found for name %s", serviceName)
+    }
+
+    if len(list[0].Location.Address) == 0 {
+        return nil, fmt.Errorf("No grpc location found for name %s - is it running?", serviceName)
+    }
+
+    addresses := []string{}
+
+    for _, item := range list {
+        addresses = append(
+            addresses,
+            fmt.Sprintf(
+                "%s:%d",
+                item.Location.Address[0].Host,
+                item.Location.Address[0].Port,
+            ),
+        )
+    }
+
+    return addresses, nil
+}
+
+// This function returns a list of hosts.
+func HostList(serviceName string, apiType pb.Apitype) ([]*pb.GetResponse, error) {
+
+	registryAddress := cmdline.GetRegistryAddress()
+
+    conn, err := grpc.Dial(
+        registryAddress,
+        grpc.WithInsecure(),
+        grpc.WithTimeout(time.Duration(CONST_CALL_TIMEOUT) * time.Second),
+    )
+    if err != nil {
+        return nil, fmt.Errorf("Error dialling servicename %s @ %s\n", serviceName, registryAddress)
+    }
+    defer conn.Close()
+
+    grpcRegistryClient := pb.NewRegistryClient(conn)
+    list, err := grpcRegistryClient.GetTarget(
+        context.Background(),
+        &pb.GetTargetRequest{
+            Name: serviceName,
+            ApiType: apiType,
+        },
+    )
+    if err != nil {
+        return nil, fmt.Errorf("Error getting grpc service address %s: %s\n", serviceName, err)
+    }
+
+    return list.Service, nil
+}


### PR DESCRIPTION
The code merged in the previous commit has been put in it's own folder as it's own package. I need to reuse this code for building a balancer.

This new registry packages exposes three functions for querying the registry service. 

GetHost
GetHosts
ListHosts

More functions may be added to this package in the future to expose more data easily from the registry server.