### PR TITLE
Split client pkg

### DIFF
--- a/client/tokens/pkg.go
+++ b/client/tokens/pkg.go
@@ -1,0 +1,77 @@
+package client
+
+import (
+	"os"
+	"fmt"
+	"flag"
+	"time"
+	"errors"
+	"strings"
+	"os/user"
+	"io/ioutil"
+	//
+	"google.golang.org/grpc/metadata"
+	//
+	"golang.org/x/net/context"
+)
+
+var (
+	displayedTokenInfo = false
+	token = flag.String("token", "user_token", "The authentication token (cookie) to authenticate with. May be name of a file in ~/.picoservices/tokens/, if so file contents shall be used as cookie")
+)
+
+func SaveToken(tk string) error {
+
+	usr, err := user.Current()
+	if err != nil {
+		fmt.Printf("Unable to get current user: %s\n", err)
+		return err
+	}
+	cfgdir := fmt.Sprintf("%s/.picoservices/tokens", usr.HomeDir)
+	fname := fmt.Sprintf("%s/%s", cfgdir, *token)
+	if _, err := os.Stat(fname); !os.IsNotExist(err) {
+		return errors.New(fmt.Sprintf("File %s exists already", fname))
+	}
+	os.MkdirAll(cfgdir, 0700)
+	fmt.Printf("Saving new token to %s\n", fname)
+	err = ioutil.WriteFile(fname, []byte(tk), 0600)
+	if err != nil {
+		fmt.Printf("Failed to save token to %s: %s\n", fname, err)
+	}
+	return err
+}
+
+func GetToken(token string) string {
+	var tok string
+	var btok []byte
+	var fname string
+	fname = "n/a"
+	usr, err := user.Current()
+	if err == nil {
+		fname = fmt.Sprintf("%s/.picoservices/tokens/%s", usr.HomeDir, token)
+		btok, _ = ioutil.ReadFile(fname)
+	}
+	if (err != nil) || (len(btok) == 0) {
+		tok = token
+	} else {
+		tok = string(btok)
+		if displayedTokenInfo {
+			fmt.Printf("Using token from %s\n", fname)
+			displayedTokenInfo = true
+		}
+	}
+	tok = strings.TrimSpace(tok)
+
+	return tok
+}
+
+func SetAuthToken(token string) context.Context {
+	tok := GetToken(token)
+	md := metadata.Pairs("token", tok,
+		"clid", "itsme",
+	)
+	millis := 5000
+	ctx, _ := context.WithTimeout(context.Background(), time.Duration(millis)*time.Millisecond)
+	ctx = metadata.NewOutgoingContext(ctx, md)
+	return ctx
+}

--- a/client/tokens/pkg.go
+++ b/client/tokens/pkg.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	displayedTokenInfo = false
-	token = flag.String("token", "user_token", "The authentication token (cookie) to authenticate with. May be name of a file in ~/.picoservices/tokens/, if so file contents shall be used as cookie")
 )
 
 func SaveToken(tk string) error {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+    "flag"
+    "time"
+    "testing"
+)
+
+func TestSendLog(t *testing.T) {
+
+    flag.Parse()
+
+    q, err := NewAsyncLogQueue("buildrepo", "?", "?", "?", "?")
+    if err != nil {
+        t.Error(err)
+        return
+    }
+
+    err = q.LogCommandStdout("this is a test searchforme", "")
+    if err != nil {
+        t.Error(err)
+        return
+    }
+
+    time.Sleep(3 *time.Second)
+}


### PR DESCRIPTION
first commit: copy funcs to new folder 'tokens'

2nd commit: remove funcs from client package

point of doing this: remove cyclic dependency when testing logService in the protoclient unit tests